### PR TITLE
Fix bad case about card-type-rocket in list_greater_cards

### DIFF
--- a/doudizhu/engine.py
+++ b/doudizhu/engine.py
@@ -514,6 +514,10 @@ class Doudizhu(object):
                 tmp_dict[card_type] = weight
         target_type = [(k, v) for k, v in iter(tmp_dict.items())]
 
+        # 如果目标牌型为rocket，则一定打不过，直接返回空
+        if target_type[0][0] == 'rocket':
+            return {}
+
         # 按牌型大小依次判断是否可用bomb, rocket
         if target_type[0][0] != 'rocket':
             if target_type[0][0] != 'bomb':


### PR DESCRIPTION
Please see this Issue: https://github.com/onestraw/doudizhu/issues/5

The list_greater_cards API will return a wrong answer, while the card type is rocket.

Thank you.